### PR TITLE
FYP-75 - [email verification] enabled and verified fields

### DIFF
--- a/user-service/src/main/java/com/fyp/userservice/model/User.java
+++ b/user-service/src/main/java/com/fyp/userservice/model/User.java
@@ -38,6 +38,12 @@ public class User {
     @Column(name = "password", length = 45, nullable = false)
     private String password;
 
+    @Column(name = "enabled", columnDefinition = "boolean default false")
+    private boolean enabled;
+
+    @Column(name = "verified", columnDefinition = "boolean default false")
+    private boolean verified;
+
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     @PrimaryKeyJoinColumn
     private UserVerifiedProfile userVerifiedProfile;

--- a/user-service/src/test/java/com/fyp/userservice/UserServiceApplicationTests.java
+++ b/user-service/src/test/java/com/fyp/userservice/UserServiceApplicationTests.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fyp.hiveshared.api.responses.HiveResponseBody;
 import com.fyp.userservice.dto.RegisterUserRequest;
 import com.fyp.userservice.dto.UserProfile;
+import com.fyp.userservice.model.User;
 import com.fyp.userservice.repository.UserRepository;
 import com.fyp.userservice.repository.UserVerifiedProfileRepository;
 import com.fyp.userservice.service.UserService;
@@ -78,6 +79,12 @@ public class UserServiceApplicationTests {
     void testCreateUser() {
         userService.registerUser(getRegisterUserRequest(VALID_EMAIL, VALID_PHONE_NUMBER, VALID_PASSWORD));
         Assertions.assertTrue(userRepository.findAll().size() == 1);
+
+        User user = userRepository.findAll().get(0);
+        Assertions.assertEquals(user.getEmail(), VALID_EMAIL);
+        Assertions.assertEquals(user.getPassword(), VALID_PASSWORD);
+        Assertions.assertEquals(user.isVerified(), false);
+        Assertions.assertEquals(user.isEnabled(), false);
     }
 
     @Test


### PR DESCRIPTION
**[FYP-75](https://trello.com/c/wTslEcgk/75-email-verification-enabled-and-verified-fields) - [email verification] enabled and verified fields**
* `enabled` and `verified` added in the `users` tables
* default of these fields is false
* Improved create user test